### PR TITLE
Hotfix do not chown or copy contents

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,17 +3,6 @@
 APACHE_CONF_DIR="/etc/apache2/"
 REVIVE_DIR="/var/www/html"
 
-# Copy the files only if revive is not installed.
-if [ ! -f "${REVIVE_DIR}/var/INSTALLED" ]; then
-  echo "Revive is not installed copying folder contents"
-  rsync -a /tmp/revive/ ${REVIVE_DIR}
-fi
-
-echo "Cleaning up"
-rm -rf /tmp/revive/
-
-chown -R www-data:www-data ${REVIVE_DIR}
-
 # Start apache in the foreground
 source ${APACHE_CONF_DIR}/envvars
 # Tail is for the logs to go to stdout.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,17 @@
 APACHE_CONF_DIR="/etc/apache2/"
 REVIVE_DIR="/var/www/html"
 
+# Copy and chown the files only if revive is not installed.
+# This is in case you are using nfs or efs.
+if [ ! -f "${REVIVE_DIR}/var/INSTALLED" ]; then
+  echo "Revive is not installed copying folder contents"
+  rsync -a /tmp/revive/ ${REVIVE_DIR}
+  chown -R www-data:www-data ${REVIVE_DIR}
+fi
+
+echo "Cleaning up"
+rm -rf /tmp/revive/
+
 # Start apache in the foreground
 source ${APACHE_CONF_DIR}/envvars
 # Tail is for the logs to go to stdout.


### PR DESCRIPTION
Chown was done on every docker start which depleted the efs burst capabilities.